### PR TITLE
Fix syntax error in openapi-generator command

### DIFF
--- a/{{cookiecutter.project_slug}}/frontend/package.json
+++ b/{{cookiecutter.project_slug}}/frontend/package.json
@@ -29,7 +29,7 @@
     "format": "prettier src --write",
     "run-e2e-tests": "cypress run",
     "open-e2e-test": "cypress open",
-    "genapi": "openapi-generator-cli generate -i <(curl -s 'http://localhost:{{ cookiecutter.backend_port }}/api/v1/openapi.json') -g typescript-axios -o src/generated -p withSeparateModelsAndApi=true,apiPackage=api,modelPackage=models,useSingleRequestParameter=true"
+    "genapi": "openapi-generator-cli generate -i 'http://localhost:{{ cookiecutter.backend_port }}/api/v1/openapi.json' -g typescript-axios -o src/generated -p withSeparateModelsAndApi=true,apiPackage=api,modelPackage=models,useSingleRequestParameter=true"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
Previously running `yarn genapi` was failing with the following error:
```
/bin/sh: 1: Syntax error: "(" unexpected
```

I believe this is because yarn is trying to run the command with `sh` instead of bash or another shell where the `<(...)` syntax is supported. However passing the URL of the endpoint seems to work just fine as well.